### PR TITLE
pmemkv: set fixed dependency version

### DIFF
--- a/pmemkv/pom.xml
+++ b/pmemkv/pom.xml
@@ -33,7 +33,7 @@ LICENSE file.
   <properties>
     <!-- extra parameters to allow easier building with pmemkv from sources -->
     <pmemkv.packageName>pmemkv-root</pmemkv.packageName>
-    <pmemkv.packageVersion>[1.1.0,)</pmemkv.packageVersion>
+    <pmemkv.packageVersion>1.1.0</pmemkv.packageVersion>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
It seems that the old version of maven does not handle well the `[...,)` syntax.